### PR TITLE
Add prominent Open button for links detected in events

### DIFF
--- a/HeadsUpKit/HeadsUpKitApp.swift
+++ b/HeadsUpKit/HeadsUpKitApp.swift
@@ -121,7 +121,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func triggerTestOverlay() {
         logger.debug("Triggering test overlay")
-        showOverlay(title: "Team Standup", description: "1. Sprint progress & blockers\n2. Code review assignments\n3. Release timeline update", location: "Apple Park, Cupertino", eventDate: Date.now.addingTimeInterval(45))
+        // A link-only location, so the debug path exercises the real derivation in OverlayContent.
+        showOverlay(OverlayContent(
+            title: "Team Standup",
+            description: "1. Sprint progress & blockers\n2. Code review assignments\n3. Release timeline update",
+            location: "https://example.com/j/1234567890",
+            eventDate: Date.now.addingTimeInterval(45)
+        ))
     }
 
     @objc private func openEventInCalendar(_ sender: NSMenuItem) {
@@ -184,21 +190,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         pendingEventID = nil
         pendingFireDate = nil
 
-        let title = event.title ?? "Upcoming Event"
-        let notes = event.notes
-        let location = event.location
-        let startDate = event.startDate
+        // Derived once here because the pending task and the overlay must never capture the EKEvent.
+        let content = OverlayContent(
+            title: event.title ?? "Upcoming Event",
+            description: event.notes,
+            location: event.location,
+            eventDate: event.startDate,
+            eventURL: event.url
+        )
         let sleepDuration = timeUntilEvent - threshold
 
         if sleepDuration <= 0, timeUntilEvent > 0 {
             // Already within threshold window — show immediately
             shownEventIDs.insert(eventID)
-            logger.info("Showing overlay for: \(title, privacy: .public) (already within threshold)")
-            showOverlay(title: title, description: notes, location: location, eventDate: startDate)
+            logger.info("Showing overlay for: \(content.title, privacy: .public) (already within threshold)")
+            showOverlay(content)
         } else if sleepDuration > 0 {
             pendingEventID = eventID
             pendingFireDate = fireDate
-            logger.info("Scheduling overlay for: \(title, privacy: .public) at \(fireDate, privacy: .public) (in \(Int(sleepDuration))s)")
+            logger.info("Scheduling overlay for: \(content.title, privacy: .public) at \(fireDate, privacy: .public) (in \(Int(sleepDuration))s)")
             pendingOverlayTask = Task {
                 // Sleep in ≤1 s increments toward an absolute fireDate rather than one long sleep.
                 // App Nap or system sleep may throttle or delay Task.sleep continuations; re-checking
@@ -209,13 +219,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     try? await Task.sleep(for: .seconds(min(remaining, 1.0)))
                 }
                 guard !Task.isCancelled else {
-                    logger.debug("Pending overlay cancelled for: \(title, privacy: .public)")
+                    logger.debug("Pending overlay cancelled for: \(content.title, privacy: .public)")
                     return
                 }
                 let delta = Date.now.timeIntervalSince(fireDate)
-                logger.info("Showing overlay for: \(title, privacy: .public) (target: \(fireDate, privacy: .public), delta: \(String(format: "%.2f", delta))s)")
+                logger.info("Showing overlay for: \(content.title, privacy: .public) (target: \(fireDate, privacy: .public), delta: \(String(format: "%.2f", delta))s)")
                 shownEventIDs.insert(eventID)
-                showOverlay(title: title, description: notes, location: location, eventDate: startDate)
+                showOverlay(content)
                 pendingEventID = nil
                 pendingOverlayTask = nil
                 pendingFireDate = nil
@@ -231,8 +241,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         layoutOverlayWindows()
     }
 
-    private func showOverlay(title: String, description: String?, location: String? = nil, eventDate: Date? = nil) {
-        let contentView = OverlayView(title: title, description: description, location: location, eventDate: eventDate) { [weak self] in
+    private func showOverlay(_ content: OverlayContent) {
+        let contentView = OverlayView(content: content) { [weak self] in
             self?.dismissOverlay()
         }
         let hostingView = NSHostingView(rootView: AnyView(contentView

--- a/HeadsUpKit/OverlayContent.swift
+++ b/HeadsUpKit/OverlayContent.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The plain values the overlay presents, derived once from the event's raw fields — the view
+/// layer must never depend on EventKit or link detection.
+struct OverlayContent {
+    let title: String
+    let description: String?
+    /// The event's location, or nil when it is empty or nothing but a link — a URL is no
+    /// physical place, and geocoding it would only ever leave the map's redacted placeholder
+    /// on screen.
+    let mapLocation: String?
+    let eventDate: Date?
+    /// Link to open for the event; an explicit event URL wins over links found in the location
+    /// (where conference links usually arrive) or in the notes.
+    let url: URL?
+
+    init(title: String, description: String?, location: String?, eventDate: Date?, eventURL: URL? = nil) {
+        self.title = title
+        self.description = description
+        self.eventDate = eventDate
+
+        let locationLink = Self.firstLink(in: location)
+        self.url = eventURL ?? locationLink?.url ?? Self.firstLink(in: description)?.url
+        self.mapLocation = (location?.isEmpty == false && locationLink?.spansWholeText != true) ? location : nil
+    }
+
+    // MARK: - Link detection
+
+    private static let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+
+    private static func firstLink(in text: String?) -> (url: URL, spansWholeText: Bool)? {
+        guard let detector,
+              let text = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty else { return nil }
+
+        let fullRange = NSRange(text.startIndex..., in: text)
+        var link: (url: URL, spansWholeText: Bool)?
+        detector.enumerateMatches(in: text, range: fullRange) { match, _, stop in
+            // The detector also reports mailto: and similar; only web links are openable here.
+            guard let match, let url = match.url,
+                  url.scheme == "http" || url.scheme == "https" else { return }
+            link = (url, match.range == fullRange)
+            stop.pointee = true
+        }
+        return link
+    }
+}

--- a/HeadsUpKit/OverlayView.swift
+++ b/HeadsUpKit/OverlayView.swift
@@ -5,12 +5,10 @@ import SwiftUI
 private let logger = Logger(subsystem: "de.juliankahnert.HeadsUpKit", category: "OverlayView")
 
 struct OverlayView: View {
-    let title: String
-    let description: String?
-    let location: String?
-    let eventDate: Date?
+    let content: OverlayContent
     let dismiss: () -> Void
 
+    @Environment(\.openURL) private var openURL
     @State private var mapPosition: MapCameraPosition?
     @State private var detailHeight: CGFloat = 0
 
@@ -31,13 +29,13 @@ struct OverlayView: View {
                 mapView
             }
 
-            dismissButton
+            actionButtons
         }
         .padding(48)
         .background(.black.opacity(0.3), in: .rect(cornerRadius: 26))
         .task {
-            if let location, !location.isEmpty {
-                await geocode(location)
+            if let mapLocation = content.mapLocation {
+                await geocode(mapLocation)
             }
         }
     }
@@ -54,12 +52,12 @@ struct OverlayView: View {
 
     private var detailsView: some View {
         VStack(spacing: 16) {
-            Text(title)
+            Text(content.title)
                 .font(.system(size: 36, weight: .bold, design: .rounded))
                 .foregroundStyle(.white)
                 .multilineTextAlignment(.center)
 
-            if let description, !description.isEmpty {
+            if let description = content.description, !description.isEmpty {
                 Text(description)
                     .font(.system(size: 18, weight: .regular, design: .rounded))
                     .foregroundStyle(.white.opacity(0.7))
@@ -68,25 +66,26 @@ struct OverlayView: View {
                     .frame(maxWidth: 360)
             }
 
-            if let eventDate, eventDate > .now {
+            if let eventDate = content.eventDate, eventDate > .now {
                 Text(timerInterval: Date.now...eventDate, countsDown: true, showsHours: false)
                     .font(.system(size: 28, weight: .semibold, design: .monospaced))
                     .foregroundStyle(.white.opacity(0.9))
             }
-        }
-    }
 
-    private var hasLocation: Bool {
-        location?.isEmpty == false
+            if let url = content.url {
+                metaLabel(url.host() ?? "Link", systemImage: "link")
+                    .lineLimit(1)
+            }
+        }
     }
 
     @ViewBuilder
     private var mapView: some View {
-        if hasLocation {
+        if let mapLocation = content.mapLocation {
             VStack(spacing: 8) {
                 if let mapPosition {
                     Map(initialPosition: mapPosition) {
-                        Marker(location ?? title, coordinate: mapPosition.region?.center ?? .init())
+                        Marker(mapLocation, coordinate: mapPosition.region?.center ?? .init())
                     }
                     .mapStyle(.standard)
                     .frame(width: detailHeight, height: detailHeight)
@@ -99,28 +98,48 @@ struct OverlayView: View {
                         .redacted(reason: .placeholder)
                 }
 
-                if let location, !location.isEmpty {
-                    Label(location, systemImage: "mappin.circle.fill")
-                        .font(.system(size: 13, design: .rounded))
-                        .foregroundStyle(.white.opacity(0.6))
-                        .lineLimit(3)
-                        .frame(maxWidth: detailHeight, alignment: .leading)
-                }
+                metaLabel(mapLocation, systemImage: "mappin.circle.fill")
+                    .lineLimit(3)
+                    .frame(maxWidth: detailHeight, alignment: .leading)
             }
         }
     }
 
-    private var dismissButton: some View {
-        Button(action: dismiss) {
-            Text("OK")
-                .font(.title3)
-                .padding(.horizontal, 32)
-                .padding(.vertical, 8)
+    private var actionButtons: some View {
+        HStack(spacing: 16) {
+            if let url = content.url {
+                Button {
+                    openURL(url)
+                    dismiss()
+                } label: {
+                    buttonLabel("Open")
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+            }
+
+            Button(action: dismiss) {
+                buttonLabel("OK")
+            }
+            .keyboardShortcut(.cancelAction)
+            .buttonStyle(.bordered)
+            .controlSize(.large)
         }
-        .keyboardShortcut(.escape, modifiers: [])
-        .buttonStyle(.bordered)
-        .controlSize(.large)
         .padding(.top, 4)
+    }
+
+    private func buttonLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.title3)
+            .padding(.horizontal, 32)
+            .padding(.vertical, 8)
+    }
+
+    private func metaLabel(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.system(size: 13, design: .rounded))
+            .foregroundStyle(.white.opacity(0.6))
     }
 
     // MARK: - Geocoding
@@ -143,22 +162,38 @@ struct OverlayView: View {
     }
 }
 
+#Preview("With Link") {
+    OverlayView(
+        content: OverlayContent(
+            title: "Team Standup",
+            description: "Daily sync with the engineering team.",
+            location: "https://example.com/j/1234567890",
+            eventDate: Date.now.addingTimeInterval(45)
+        ),
+        dismiss: {}
+    )
+}
+
 #Preview("With Location") {
     OverlayView(
-        title: "Team Standup",
-        description: "Daily sync with the engineering team.",
-        location: "Apple Park, Cupertino",
-        eventDate: Date.now.addingTimeInterval(45),
+        content: OverlayContent(
+            title: "Team Standup",
+            description: "Daily sync with the engineering team.",
+            location: "Apple Park, Cupertino",
+            eventDate: Date.now.addingTimeInterval(45)
+        ),
         dismiss: {}
     )
 }
 
 #Preview("Without Location") {
     OverlayView(
-        title: "Team Standup",
-        description: "Daily sync with the engineering team.",
-        location: nil,
-        eventDate: Date.now.addingTimeInterval(30),
+        content: OverlayContent(
+            title: "Team Standup",
+            description: "Daily sync with the engineering team.",
+            location: nil,
+            eventDate: Date.now.addingTimeInterval(30)
+        ),
         dismiss: {}
     )
 }


### PR DESCRIPTION
## Summary

When a link can be detected for the event shown in the fullscreen overlay, a prominent **Open** button appears that opens the link and dismisses the overlay.

- New `OverlayContent` value type derives the overlay's plain values once from the event's raw fields:
  - `url`: explicit event URL wins over the first http(s) link found in the location (where conference links usually arrive) or the notes — detected via a single-pass `NSDataDetector` scan.
  - `mapLocation`: `nil` when the location is nothing but a URL, so the map, its geocoding attempt, and the previously never-resolving redacted placeholder are skipped for link-only locations.
- `OverlayView` is now pure presentation: no EventKit or link-detection dependency, opens links via the SwiftUI `openURL` environment. Open uses Return (`.defaultAction`), OK keeps Escape via `.cancelAction`.
- The DEBUG "Test Overlay" menu item and the previews construct `OverlayContent`, so both exercise the real link derivation instead of re-implementing fragments of it.
- Without a detected link the overlay is unchanged.

## Test plan

- `xcodebuild -scheme HeadsUpKit -configuration Debug build` succeeds with no new warnings
- Previews: "With Link" (Open button, no map), "With Location" (map, no Open button), "Without Location"
- DEBUG menu "Test Overlay" shows the Open button for a link-only location